### PR TITLE
Bugfix in splitPipe: Set link initial status

### DIFF
--- a/epyt/epanet.py
+++ b/epyt/epanet.py
@@ -9878,7 +9878,7 @@ class epanet:
         self.setLinkPipeData(leftPipeIndex, linkLength, linkDia, linkRoughnessCoeff, linkMinorLossCoeff)
         if linkMinorLossCoeff != 0:
             self.setLinklinkMinorLossCoeff(leftPipeIndex, linkMinorLossCoeff)
-        self.setLinkInitialSetting(leftPipeIndex, linkInitialSetting)
+        self.setLinkInitialStatus(leftPipeIndex, linkInitialStatus)
         self.setLinkInitialSetting(leftPipeIndex, linkInitialSetting)
         self.setLinkBulkReactionCoeff(leftPipeIndex, linkBulkReactionCoeff)
         self.setLinkWallReactionCoeff(leftPipeIndex, linkWallReactionCoeff)


### PR DESCRIPTION
Found and fixed a bug in the `splitPipe()` method concerning the initial status of the new link.