### PR TITLE
Several fixes regarding rules

### DIFF
--- a/epyt/epanet.py
+++ b/epyt/epanet.py
@@ -10625,7 +10625,7 @@ class epanet:
             else:
                 time_ = splitControl[5].split(':')
                 controlLevel = int(time_[0]) * 3600 + int(time_[1]) * 60
-                if "PM" == splitControl[6]:
+                if splitControl.__len__() > 6 and "PM" == splitControl[6]:
                     controlLevel += 43200
         return [controlTypeIndex, linkIndex, controlSettingValue, nodeIndex, controlLevel]
 

--- a/epyt/epanet.py
+++ b/epyt/epanet.py
@@ -6078,7 +6078,7 @@ class epanet:
                     objectNameID = ' '
                     space = ''
                 if variable >= self.ToolkitConstants.EN_R_TIME:
-                    value_premise = datetime.utcfromtimestamp(value_premise).strftime("%I:%M %p UTC")
+                    value_premise = datetime.fromtimestamp(value_premise).strftime("%I:%M %p")
                 else:
                     value_premise = str(value_premise)
                 if status == 0:

--- a/epyt/epanet.py
+++ b/epyt/epanet.py
@@ -64,7 +64,7 @@ from ctypes import cdll, byref, create_string_buffer, c_uint64, c_uint32, c_void
     c_char_p
 from types import SimpleNamespace
 import matplotlib.pyplot as plt
-from datetime import datetime
+from datetime import datetime, timezone
 from epyt import __version__, __msxversion__, __lastupdate__
 from shutil import copyfile
 from matplotlib import cm
@@ -6078,7 +6078,7 @@ class epanet:
                     objectNameID = ' '
                     space = ''
                 if variable >= self.ToolkitConstants.EN_R_TIME:
-                    value_premise = datetime.fromtimestamp(value_premise).strftime("%I:%M %p")
+                    value_premise = datetime.fromtimestamp(value_premise, tz=timezone.utc).strftime("%I:%M %p")
                 else:
                     value_premise = str(value_premise)
                 if status == 0:

--- a/epyt/epanet.py
+++ b/epyt/epanet.py
@@ -10625,6 +10625,8 @@ class epanet:
             else:
                 time_ = splitControl[5].split(':')
                 controlLevel = int(time_[0]) * 3600 + int(time_[1]) * 60
+                if "PM" == splitControl[6]:
+                    controlLevel += 43200
         return [controlTypeIndex, linkIndex, controlSettingValue, nodeIndex, controlLevel]
 
     def __createTempfiles(self, BinTempfile):


### PR DESCRIPTION
This pull request addresses two issues regarding rules:
- Fixing a datetime deprecation warning in getRules and removing the time zone from the string. Note that 1) the time zone is not required and does not make any sense, and 2) it violates the EPANET rule formatting.
- Fixing a bug in __controlSettings for parsing clock times. This fix ensures that PM clock times are processed correctly.

I need this bugfix for the next release of EPyT-Flow -- would be great if you could create a new release of EPyT.

Many thanks and best wishes,
André